### PR TITLE
fix: correct duration unit conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2] - 2025-12-25
+
+### 🐛 Bug Fixes
+
+- Correct duration unit conversions
+
+### 🧪 Testing
+
+- Add duration unit precision tests
+
 ## [0.5.1] - 2025-12-25
 
 ### 🚀 Features
@@ -21,6 +31,10 @@ All notable changes to this project will be documented in this file.
 ### 🧪 Testing
 
 - Improve test structure and add fmt import
+
+### ⚙️ Miscellaneous Tasks
+
+- Update changelog for v0.5.1
 
 ## [0.3.1] - 2025-03-01
 

--- a/ft.go
+++ b/ft.go
@@ -216,7 +216,7 @@ func (s *span) End() {
 			if durationMetricUnit == DurationMetricUnitSecond {
 				histogram.Record(s.ctx, duration.Seconds())
 			} else {
-				histogram.Record(s.ctx, float64(duration.Milliseconds())/1000)
+				histogram.Record(s.ctx, durationToMillisecond(duration))
 			}
 		}
 	}
@@ -264,9 +264,9 @@ func mapSlogAttrToOtel(v slog.Attr) attribute.KeyValue {
 }
 
 func durationToMillisecond(d time.Duration) float64 {
-	return float64(d/1000) / 1000
+	return float64(d) / float64(time.Millisecond)
 }
 
 func durationToSecond(d time.Duration) float64 {
-	return float64(d/1000) / 1000000
+	return float64(d) / float64(time.Second)
 }

--- a/ft_internal_test.go
+++ b/ft_internal_test.go
@@ -1,0 +1,18 @@
+package ft
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDurationConversionPrecision(t *testing.T) {
+	d := time.Second + 123*time.Nanosecond
+
+	expectedMs := float64(d) / float64(time.Millisecond)
+	expectedSeconds := float64(d) / float64(time.Second)
+
+	assert.InDelta(t, expectedMs, durationToMillisecond(d), 1e-12)
+	assert.InDelta(t, expectedSeconds, durationToSecond(d), 1e-12)
+}


### PR DESCRIPTION
## Summary

- fix duration metric unit conversions and histogram recording
- add tests for duration unit precision\n- update changelog for v0.5.2
